### PR TITLE
trunk/branches/tags not always the first entry in the relative URL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# To use this file you must have EditorConfig installed for your editor.
+# For Visual Studio Code, install the extension: "EditorConfig for VS Code"
+# https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.{ps1,psd1,psm1}]
+trim_trailing_whitespace = true

--- a/CheckVersion.ps1
+++ b/CheckVersion.ps1
@@ -1,0 +1,19 @@
+$Global:SvnMissing = $false
+
+if (!(Get-Command svn -TotalCount 1 -ErrorAction SilentlyContinue)) {
+    Write-Warning "svn command could not be found. Please create an alias or add it to your PATH."
+    $Global:SvnMissing = $true
+    return
+}
+
+# HACK determine a minimum required version, 1.6.0 is a guess
+$requiredVersion = [Version]'1.6.0'
+if ([String](svn --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+    $version = [Version]$Matches['ver']
+}
+if ($version -lt $requiredVersion) {
+    Write-Warning "posh-svn requires Subversion $requiredVersion or better. You have $version."
+    $false
+} else {
+    $true
+}

--- a/CheckVersion.ps1
+++ b/CheckVersion.ps1
@@ -14,6 +14,7 @@ if ([String](svn --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
 if ($version -lt $requiredVersion) {
     Write-Warning "posh-svn requires Subversion $requiredVersion or better. You have $version."
     $false
-} else {
+}
+else {
     $true
 }

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -20,11 +20,11 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     FileConflictedText                      = '!'
 
     LocalDefaultStatusSymbol                = $null
-    LocalDefaultStatusForegroundColor       = Get-ConsoleThemeSafeColor Green
+    LocalDefaultStatusForegroundColor       = [ConsoleColor]::DarkGreen
     LocalDefaultStatusBackgroundColor       = $null
 
     LocalWorkingStatusSymbol                = '!'
-    LocalWorkingStatusForegroundColor       = Get-ConsoleThemeSafeColor Red
+    LocalWorkingStatusForegroundColor       = [ConsoleColor]::DarkRed
     LocalWorkingStatusBackgroundColor       = $null
 
     LocalStagedStatusSymbol                 = '~'
@@ -38,10 +38,10 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     RevisionForegroundColor                 = [ConsoleColor]::DarkGray
     RevisionBackgroundColor                 = $null
 
-    IndexForegroundColor                    = Get-ConsoleThemeSafeColor Green
+    IndexForegroundColor                    = [ConsoleColor]::DarkGreen
     IndexBackgroundColor                    = $null
 
-    WorkingForegroundColor                  = Get-ConsoleThemeSafeColor Red
+    WorkingForegroundColor                  = [ConsoleColor]::DarkRed
     WorkingBackgroundColor                  = $null
 
     ExternalStatusSymbol                    = [char]0x2190 # arrow right

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -1,7 +1,7 @@
 $global:SvnPromptSettings = [PSCustomObject]@{
     DefaultForegroundColor                  = $null
     DefaultBackgroundColor                  = $null
-    
+
     BeforeText                              = ' ['
     BeforeForegroundColor                   = [ConsoleColor]::Yellow
     BeforeBackgroundColor                   = $null
@@ -18,7 +18,7 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     FileModifiedText                        = '~'
     FileRemovedText                         = '-'
     FileConflictedText                      = '!'
-    
+
     LocalDefaultStatusSymbol                = $null
     LocalDefaultStatusForegroundColor       = Get-ConsoleThemeSafeColor Green
     LocalDefaultStatusBackgroundColor       = $null
@@ -37,7 +37,7 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     RevisionText                            = '@'
     RevisionForegroundColor                 = [ConsoleColor]::DarkGray
     RevisionBackgroundColor                 = $null
-    
+
     IndexForegroundColor                    = Get-ConsoleThemeSafeColor Green
     IndexBackgroundColor                    = $null
 
@@ -64,21 +64,18 @@ $global:SvnPromptSettings = [PSCustomObject]@{
 }
 
 $WindowTitleSupported = $true
-if (Get-Module NuGet)
-{
+if (Get-Module NuGet) {
     $WindowTitleSupported = $false
 }
 
-function Write-Prompt
-{
-    param
-    (
+function Write-Prompt {
+    param (
         [Parameter(Position = 0, Mandatory = $true)]
         $Object,
-        
+
         [Parameter(Mandatory = $false)]
         [Nullable[ConsoleColor]] $ForegroundColor = $SvnPromptSettings.DefaultForegroundColor,
-        
+
         [Parameter(Mandatory = $false)]
         [Nullable[ConsoleColor]] $BackgroundColor = $SvnPromptSettings.DefaultBackgroundColor,
 
@@ -90,122 +87,100 @@ function Write-Prompt
         NoNewLine = $true;
     }
 
-    if (Test-ConsoleColor $BackgroundColor)
-    {
+    if (Test-ConsoleColor $BackgroundColor) {
         $writeHostParams.BackgroundColor = $BackgroundColor
     }
-    
-    if (Test-ConsoleColor $ForegroundColor)
-    {
+
+    if (Test-ConsoleColor $ForegroundColor) {
         $writeHostParams.ForegroundColor = $ForegroundColor
     }
 
     Write-Host @writeHostParams
 }
 
-function Write-SvnStatus($status)
-{
+function Write-SvnStatus($status) {
     $s = $global:SvnPromptSettings
-    if ($status -and $s)
-    {
+    if ($status -and $s) {
         Write-Prompt $s.BeforeText -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         Write-Prompt $status.Branch -BackgroundColor $s.BranchBackgroundColor -ForegroundColor $s.BranchForegroundColor
         Write-Prompt "$($s.RevisionText)$($status.Revision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor -StrictSafeColors
 
-        if ($status.HasIndex)
-        {
-            if ($s.ShowStatusWhenZero -or $status.Added)
-            {
+        if ($status.HasIndex) {
+            if ($s.ShowStatusWhenZero -or $status.Added) {
                 Write-Prompt " $($s.FileAddedText)$($status.Added)" -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor
             }
-            if ($s.ShowStatusWhenZero -or $status.Modified)
-            {
+            if ($s.ShowStatusWhenZero -or $status.Modified) {
                 Write-Prompt " $($s.FileModifiedText)$($status.Modified)" -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor
             }
-            if ($s.ShowStatusWhenZero -or $status.Deleted)
-            {
+            if ($s.ShowStatusWhenZero -or $status.Deleted) {
                 Write-Prompt " $($s.FileRemovedText)$($status.Deleted)" -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor
             }
         }
 
-        if ($status.HasWorking)
-        {
-            if ($status.HasIndex)
-            {
+        if ($status.HasWorking) {
+            if ($status.HasIndex) {
                 Write-Prompt $s.DelimText -BackgroundColor $s.DelimBackgroundColor -ForegroundColor $s.DelimForegroundColor
             }
 
-            if ($status.Untracked)
-            {
+            if ($status.Untracked) {
                 Write-Prompt " $($s.FileAddedText)$($status.Untracked)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
 
-            if ($status.Missing)
-            {
+            if ($status.Missing) {
                 Write-Prompt " $($s.FileRemovedText)$($status.Missing)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
 
-            if ($status.Conflicted)
-            {
+            if ($status.Conflicted) {
                 Write-Prompt " $($s.FileConflictedText)$($status.Conflicted)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
         }
 
-        if ($status.Incoming)
-        {
+        if ($status.Incoming) {
             Write-Prompt " $($s.IncomingStatusSymbol)$($status.Incoming)" -BackgroundColor $s.IncomingBackgroundColor -ForegroundColor $s.IncomingForegroundColor
             Write-Prompt "$($s.RevisionText)$($status.IncomingRevision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor -StrictSafeColors
         }
 
-        if ($status.HasIndex)
-        {
+        if ($status.HasIndex) {
             # We have uncommitted files
             $localStatusSymbol          = $s.LocalStagedStatusSymbol
             $localStatusBackgroundColor = $s.LocalStagedStatusBackgroundColor
             $localStatusForegroundColor = $s.LocalStagedStatusForegroundColor
         }
-        elseif ($status.HasWorking)
-        {
+        elseif ($status.HasWorking) {
             # We have uncommitted files
             $localStatusSymbol          = $s.LocalWorkingStatusSymbol
             $localStatusBackgroundColor = $s.LocalWorkingStatusBackgroundColor
             $localStatusForegroundColor = $s.LocalWorkingStatusForegroundColor
         }
-        else
-        {
+        else {
             # No uncommited changes
             $localStatusSymbol          = $s.LocalDefaultStatusSymbol
             $localStatusBackgroundColor = $s.LocalDefaultStatusBackgroundColor
             $localStatusForegroundColor = $s.LocalDefaultStatusForegroundColor
         }
 
-        if ($s.ShowExternals -and $status.External)
-        {
-            if ($status.HasWorking -or $status.HasIndex)
-            {
+        if ($s.ShowExternals -and $status.External) {
+            if ($status.HasWorking -or $status.HasIndex) {
                 Write-Prompt $s.DelimText -BackgroundColor $s.DelimBackgroundColor -ForegroundColor $s.DelimForegroundColor
             }
-                
+
             Write-Prompt " $($s.ExternalStatusSymbol)$($status.External)" -BackgroundColor $s.ExternalBackgroundColor -ForegroundColor $s.ExternalForegroundColor -StrictSafeColors
         }
 
-        if ($localStatusSymbol)
-        {
+        if ($localStatusSymbol) {
             Write-Prompt (" {0}" -f $localStatusSymbol) -BackgroundColor $localStatusBackgroundColor -ForegroundColor $localStatusForegroundColor
         }
 
         Write-Prompt $s.AfterText -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
 
-        if ($WindowTitleSupported -and $status.Title)
-        {
+        if ($WindowTitleSupported -and $status.Title) {
             $Global:CurrentWindowTitle += ' ~ ' + $status.Title
         }
     }
 }
 
 # Should match https://github.com/dahlbyk/posh-git/blob/master/GitPrompt.ps1
-if (!(Test-Path Variable:Global:VcsPromptStatuses))
-{
+if (!(Test-Path Variable:Global:VcsPromptStatuses)) {
     $Global:VcsPromptStatuses = @()
 }
 
@@ -219,9 +194,8 @@ $Global:VcsPromptStatuses += $PoshSvnVcsPrompt
 $ExecutionContext.SessionState.Module.OnRemove = {
     $c = $Global:VcsPromptStatuses.Count
     $global:VcsPromptStatuses = @( $global:VcsPromptStatuses | Where-Object { $_ -ne $PoshSvnVcsPrompt -and $_ -inotmatch '\bWrite-SvnStatus\b' } ) # cdonnelly 2017-08-01: if the script is redefined in a different module
-    
-    if ($c -ne 1 + $Global:VcsPromptStatuses.Count)
-    {
+
+    if ($c -ne 1 + $Global:VcsPromptStatuses.Count) {
         Write-Warning "posh-svn: did not remove prompt"
     }
 }

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -31,7 +31,7 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     LocalStagedStatusForegroundColor        = Get-ConsoleThemeSafeColor Cyan
     LocalStagedStatusBackgroundColor        = $null
 
-    BranchForegroundColor                   = [ConsoleColor]::Cyan
+    BranchForegroundColor                   = Get-ConsoleThemeSafeColor Cyan
     BranchBackgroundColor                   = $null
 
     RevisionText                            = '@'
@@ -93,23 +93,11 @@ function Write-Prompt
     if (Test-ConsoleColor $BackgroundColor)
     {
         $writeHostParams.BackgroundColor = $BackgroundColor
-        if (Test-ConsoleColor $ForegroundColor)
-        {
-            # background color is set, we don't need "safe" color
-            $writeHostParams.ForegroundColor = $ForegroundColor
-        }
     }
-    elseif (Test-ConsoleColor $ForegroundColor)
+    
+    if (Test-ConsoleColor $ForegroundColor)
     {
-        # don't do safe colors unless it's actually the same.
-        if ($StrictSafeColors -and $ForegroundColor -ne $ConsoleTheme.Default.BackgroundColor)
-        {
-            $writeHostParams.ForegroundColor = $ForegroundColor
-        }
-        else
-        {
-            $writeHostParams.ForegroundColor = Get-ConsoleThemeSafeColor -Color $ForegroundColor
-        }
+        $writeHostParams.ForegroundColor = $ForegroundColor
     }
 
     Write-Host @writeHostParams
@@ -166,7 +154,7 @@ function Write-SvnStatus($status)
         if ($status.Incoming)
         {
             Write-Prompt " $($s.IncomingStatusSymbol)$($status.Incoming)" -BackgroundColor $s.IncomingBackgroundColor -ForegroundColor $s.IncomingForegroundColor
-            Write-Prompt "$($s.RevisionText)$($status.IncomingRevision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
+            Write-Prompt "$($s.RevisionText)$($status.IncomingRevision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor -StrictSafeColors
         }
 
         if ($status.HasIndex)

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -28,10 +28,10 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     LocalWorkingStatusBackgroundColor       = $null
 
     LocalStagedStatusSymbol                 = '~'
-    LocalStagedStatusForegroundColor        = Get-ConsoleThemeSafeColor Cyan
+    LocalStagedStatusForegroundColor        = [ConsoleColor]::Cyan
     LocalStagedStatusBackgroundColor        = $null
 
-    BranchForegroundColor                   = Get-ConsoleThemeSafeColor Cyan
+    BranchForegroundColor                   = [ConsoleColor]::Cyan
     BranchBackgroundColor                   = $null
 
     RevisionText                            = '@'
@@ -77,9 +77,7 @@ function Write-Prompt {
         [Nullable[ConsoleColor]] $ForegroundColor = $SvnPromptSettings.DefaultForegroundColor,
 
         [Parameter(Mandatory = $false)]
-        [Nullable[ConsoleColor]] $BackgroundColor = $SvnPromptSettings.DefaultBackgroundColor,
-
-        [switch] $StrictSafeColors
+        [Nullable[ConsoleColor]] $BackgroundColor = $SvnPromptSettings.DefaultBackgroundColor
     )
 
     $writeHostParams = @{
@@ -103,7 +101,7 @@ function Write-SvnStatus($status) {
     if ($status -and $s) {
         Write-Prompt $s.BeforeText -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         Write-Prompt $status.Branch -BackgroundColor $s.BranchBackgroundColor -ForegroundColor $s.BranchForegroundColor
-        Write-Prompt "$($s.RevisionText)$($status.Revision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor -StrictSafeColors
+        Write-Prompt "$($s.RevisionText)$($status.Revision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
 
         if ($status.HasIndex) {
             if ($s.ShowStatusWhenZero -or $status.Added) {
@@ -137,7 +135,7 @@ function Write-SvnStatus($status) {
 
         if ($status.Incoming) {
             Write-Prompt " $($s.IncomingStatusSymbol)$($status.Incoming)" -BackgroundColor $s.IncomingBackgroundColor -ForegroundColor $s.IncomingForegroundColor
-            Write-Prompt "$($s.RevisionText)$($status.IncomingRevision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor -StrictSafeColors
+            Write-Prompt "$($s.RevisionText)$($status.IncomingRevision)" -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
         }
 
         if ($status.HasIndex) {
@@ -164,7 +162,7 @@ function Write-SvnStatus($status) {
                 Write-Prompt $s.DelimText -BackgroundColor $s.DelimBackgroundColor -ForegroundColor $s.DelimForegroundColor
             }
 
-            Write-Prompt " $($s.ExternalStatusSymbol)$($status.External)" -BackgroundColor $s.ExternalBackgroundColor -ForegroundColor $s.ExternalForegroundColor -StrictSafeColors
+            Write-Prompt " $($s.ExternalStatusSymbol)$($status.External)" -BackgroundColor $s.ExternalBackgroundColor -ForegroundColor $s.ExternalForegroundColor
         }
 
         if ($localStatusSymbol) {

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -18,7 +18,7 @@ $global:SvnPromptSettings = [PSCustomObject]@{
     FileModifiedText                        = '~'
     FileRemovedText                         = '-'
     FileConflictedText                      = '!'
-
+    
     LocalDefaultStatusSymbol                = $null
     LocalDefaultStatusForegroundColor       = Get-ConsoleThemeSafeColor Green
     LocalDefaultStatusBackgroundColor       = $null
@@ -137,17 +137,17 @@ function Write-SvnStatus($status)
 
             if ($status.Untracked)
             {
-                Write-Prompt " ?$($status.Untracked)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+                Write-Prompt " $($s.FileAddedText)$($status.Untracked)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
 
             if ($status.Missing)
             {
-                Write-Prompt " !$($status.Missing)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+                Write-Prompt " $($s.FileRemovedText)$($status.Missing)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
 
             if ($status.Conflicted)
             {
-                Write-Prompt " $($status.FileConflictedText)$($status.Conflicted)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+                Write-Prompt " $($s.FileConflictedText)$($status.Conflicted)" -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
             }
         }
 

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -1,97 +1,110 @@
 $global:SvnPromptSettings = New-Object PSObject -Property @{
-    BeforeText                = ' ['
-    BeforeForegroundColor     = [ConsoleColor]::Yellow
-    BeforeBackgroundColor     = $Host.UI.RawUI.BackgroundColor
+    BeforeText               = ' ['
+    BeforeForegroundColor    = [ConsoleColor]::Yellow
+    BeforeBackgroundColor    = $Host.UI.RawUI.BackgroundColor
 
-    AfterText                 = ']'
-    AfterForegroundColor      = [ConsoleColor]::Yellow
-    AfterBackgroundColor      = $Host.UI.RawUI.BackgroundColor
+    AfterText                = ']'
+    AfterForegroundColor     = [ConsoleColor]::Yellow
+    AfterBackgroundColor     = $Host.UI.RawUI.BackgroundColor
 
-    BranchForegroundColor     = [ConsoleColor]::Cyan
-    BranchBackgroundColor     = $Host.UI.RawUI.BackgroundColor
+    BranchForegroundColor    = [ConsoleColor]::Cyan
+    BranchBackgroundColor    = $Host.UI.RawUI.BackgroundColor
 
-    RevisionForegroundColor   = [ConsoleColor]::DarkGray
-    RevisionBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+    RevisionForegroundColor  = [ConsoleColor]::DarkGray
+    RevisionBackgroundColor  = $Host.UI.RawUI.BackgroundColor
 
-    WorkingForegroundColor    = [ConsoleColor]::Yellow
-    WorkingBackgroundColor    = $Host.UI.RawUI.BackgroundColor
+    WorkingForegroundColor   = [ConsoleColor]::Yellow
+    WorkingBackgroundColor   = $Host.UI.RawUI.BackgroundColor
 
-    ExternalStatusSymbol      = [char]0x2190 # arrow right
-    ExternalForegroundColor   = [ConsoleColor]::DarkMagenta
-    ExternalBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+    ExternalStatusSymbol     = [char]0x2190 # arrow right
+    ExternalForegroundColor  = [ConsoleColor]::DarkMagenta
+    ExternalBackgroundColor  = $Host.UI.RawUI.BackgroundColor
 
-    IncomingStatusSymbol      = [char]0x2193 # Down arrow
-    IncomingForegroundColor   = [ConsoleColor]::Red
-    IncomingBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+    IncomingStatusSymbol     = [char]0x2193 # Down arrow
+    IncomingForegroundColor  = [ConsoleColor]::Red
+    IncomingBackgroundColor  = $Host.UI.RawUI.BackgroundColor
 
-    EnablePromptStatus        = !$Global:SvnMissing
+    EnablePromptStatus       = !$Global:SvnMissing
 
-    EnableRemoteStatus        = $true   # show remote server status
-    EnableExternalFileStatus  = $false  # include files from externals in counts
+    EnableRemoteStatus       = $true   # show remote server status
+    EnableExternalFileStatus = $false  # include files from externals in counts
 
-    EnableWindowTitle         = 'svn ~ '
+    EnableWindowTitle        = 'svn ~ '
 }
 
 $WindowTitleSupported = $true
-if (Get-Module NuGet) {
+if (Get-Module NuGet)
+{
     $WindowTitleSupported = $false
 }
 
-function Write-SvnStatus($status) {
+function Write-SvnStatus($status)
+{
     $s = $global:SvnPromptSettings
-    if ($status -and $s) {
+    if ($status -and $s)
+    {
         Write-Prompt $s.BeforeText -NoNewline -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         Write-Prompt $status.Branch -NoNewline -BackgroundColor $s.BranchBackgroundColor -ForegroundColor $s.BranchForegroundColor
         Write-Prompt "@$($status.Revision)" -NoNewline -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
 
-        if($status.Added) {
-          Write-Prompt " +$($status.Added)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+        if ($status.Added)
+        {
+            Write-Prompt " +$($status.Added)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
         }
-        if($status.Modified) {
-          Write-Prompt " ~$($status.Modified)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+        if ($status.Modified)
+        {
+            Write-Prompt " ~$($status.Modified)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
         }
-        if($status.Deleted) {
-          Write-Prompt " -$($status.Deleted)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
-        }
-
-        if ($status.Untracked) {
-          Write-Prompt " ?$($status.Untracked)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
-        }
-
-        if($status.Missing) {
-           Write-Prompt " !$($status.Missing)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+        if ($status.Deleted)
+        {
+            Write-Prompt " -$($status.Deleted)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
         }
 
-        if($status.Conflicted) {
-          Write-Prompt " C$($status.Conflicted)" -NoNewLine -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+        if ($status.Untracked)
+        {
+            Write-Prompt " ?$($status.Untracked)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
         }
 
-        if($status.Incoming) {
-          Write-Prompt " $($s.IncomingStatusSymbol)$($status.Incoming)" -NoNewLine -BackgroundColor $s.IncomingBackgroundColor -ForegroundColor $s.IncomingForegroundColor
-          Write-Prompt "@$($status.IncomingRevision)" -NoNewline -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
+        if ($status.Missing)
+        {
+            Write-Prompt " !$($status.Missing)" -NoNewline -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
         }
 
-        if($status.External) {
-          Write-Prompt " $($s.ExternalStatusSymbol)$($status.External)" -NoNewLine -BackgroundColor $s.ExternalBackgroundColor -ForegroundColor $s.ExternalForegroundColor
+        if ($status.Conflicted)
+        {
+            Write-Prompt " C$($status.Conflicted)" -NoNewLine -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor
+        }
+
+        if ($status.Incoming)
+        {
+            Write-Prompt " $($s.IncomingStatusSymbol)$($status.Incoming)" -NoNewLine -BackgroundColor $s.IncomingBackgroundColor -ForegroundColor $s.IncomingForegroundColor
+            Write-Prompt "@$($status.IncomingRevision)" -NoNewline -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
+        }
+
+        if ($status.External)
+        {
+            Write-Prompt " $($s.ExternalStatusSymbol)$($status.External)" -NoNewLine -BackgroundColor $s.ExternalBackgroundColor -ForegroundColor $s.ExternalForegroundColor
         }
 
         Write-Prompt $s.AfterText -NoNewline -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
 
-        if ($WindowTitleSupported -and $status.Title) {
+        if ($WindowTitleSupported -and $status.Title)
+        {
             $Global:CurrentWindowTitle += ' ~ ' + $status.Title
         }
     }
 }
 
 # Should match https://github.com/dahlbyk/posh-git/blob/master/GitPrompt.ps1
-if(!(Test-Path Variable:Global:VcsPromptStatuses)) {
+if (!(Test-Path Variable:Global:VcsPromptStatuses))
+{
     $Global:VcsPromptStatuses = @()
 }
 
 # Scriptblock that will execute for write-vcsstatus
 $PoshSvnVcsPrompt = {
-	$Global:SvnStatus = Get-SvnStatus
-	Write-SvnStatus $SvnStatus
+    $Global:SvnStatus = Get-SvnStatus
+    Write-SvnStatus $SvnStatus
 }
 
 $Global:VcsPromptStatuses += $PoshSvnVcsPrompt
@@ -99,7 +112,8 @@ $ExecutionContext.SessionState.Module.OnRemove = {
     $c = $Global:VcsPromptStatuses.Count
     $global:VcsPromptStatuses = @( $global:VcsPromptStatuses | Where-Object { $_ -ne $PoshSvnVcsPrompt -and $_ -inotmatch '\bWrite-SvnStatus\b' } ) # cdonnelly 2017-08-01: if the script is redefined in a different module
     
-    if ($c -ne 1 + $Global:VcsPromptStatuses.Count) {
-      Write-Warning "posh-svn: did not remove prompt"
+    if ($c -ne 1 + $Global:VcsPromptStatuses.Count)
+    {
+        Write-Warning "posh-svn: did not remove prompt"
     }
 }

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -28,12 +28,18 @@ $global:SvnPromptSettings = New-Object PSObject -Property @{
 
     EnableRemoteStatus        = $true   # show remote server status
     EnableExternalFileStatus  = $false  # include files from externals in counts
+
+    EnableWindowTitle                           = 'posh~svn ~ '
+}
+
+$WindowTitleSupported = $true
+if (Get-Module NuGet) {
+    $WindowTitleSupported = $false
 }
 
 function Write-SvnStatus($status) {
-    if ($status) {
-        $s = $global:SvnPromptSettings
-
+    $s = $global:SvnPromptSettings
+    if ($status -and $s) {
         Write-Prompt $s.BeforeText -NoNewline -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         Write-Prompt $status.Branch -NoNewline -BackgroundColor $s.BranchBackgroundColor -ForegroundColor $s.BranchForegroundColor
         Write-Prompt "@$($status.Revision)" -NoNewline -BackgroundColor $s.RevisionBackgroundColor -ForegroundColor $s.RevisionForegroundColor
@@ -70,6 +76,17 @@ function Write-SvnStatus($status) {
         }
 
         Write-Prompt $s.AfterText -NoNewline -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
+
+        if ($WindowTitleSupported -and $s.EnableWindowTitle) {
+            if( -not $Global:PreviousWindowTitle ) {
+                $Global:PreviousWindowTitle = $Host.UI.RawUI.WindowTitle
+            }
+            $repoName = Split-Path -Leaf (Split-Path $status.SvnDir)
+            $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
+            $Host.UI.RawUI.WindowTitle = "$script:adminHeader$prefix$repoName [$($status.Branch)]"
+        }
+    } elseif ( $Global:PreviousWindowTitle ) {
+        $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
     }
 }
 

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -85,4 +85,11 @@ $PoshSvnVcsPrompt = {
 }
 
 $Global:VcsPromptStatuses += $PoshSvnVcsPrompt
-$ExecutionContext.SessionState.Module.OnRemove = { $Global:VcsPromptStatuses = $Global:VcsPromptStatuses | ? { $_ -ne $PoshSvnVcsPrompt} }
+$ExecutionContext.SessionState.Module.OnRemove = {
+    $c = $Global:VcsPromptStatuses.Count
+    $global:VcsPromptStatuses = @( $global:VcsPromptStatuses | Where-Object { $_ -ne $PoshSvnVcsPrompt -and $_ -inotmatch '\bWrite-SvnStatus\b' } ) # cdonnelly 2017-08-01: if the script is redefined in a different module
+    
+    if ($c -ne 1 + $Global:VcsPromptStatuses.Count) {
+      Write-Warning "posh-svn: did not remove prompt"
+    }
+}

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -29,7 +29,7 @@ $global:SvnPromptSettings = New-Object PSObject -Property @{
     EnableRemoteStatus        = $true   # show remote server status
     EnableExternalFileStatus  = $false  # include files from externals in counts
 
-    EnableWindowTitle                           = 'posh~svn ~ '
+    EnableWindowTitle         = 'svn ~ '
 }
 
 $WindowTitleSupported = $true
@@ -77,16 +77,9 @@ function Write-SvnStatus($status) {
 
         Write-Prompt $s.AfterText -NoNewline -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
 
-        if ($WindowTitleSupported -and $s.EnableWindowTitle) {
-            if( -not $Global:PreviousWindowTitle ) {
-                $Global:PreviousWindowTitle = $Host.UI.RawUI.WindowTitle
-            }
-            $repoName = Split-Path -Leaf (Split-Path $status.SvnDir)
-            $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
-            $Host.UI.RawUI.WindowTitle = "$script:adminHeader$prefix$repoName [$($status.Branch)]"
+        if ($WindowTitleSupported -and $status.Title) {
+            $Global:CurrentWindowTitle += ' ~ ' + $status.Title
         }
-    } elseif ( $Global:PreviousWindowTitle ) {
-        $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
     }
 }
 

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -24,6 +24,8 @@ $global:SvnPromptSettings = New-Object PSObject -Property @{
     IncomingForegroundColor   = [ConsoleColor]::Red
     IncomingBackgroundColor   = $Host.UI.RawUI.BackgroundColor
 
+    EnablePromptStatus        = !$Global:SvnMissing
+
     EnableRemoteStatus        = $true   # show remote server status
     EnableExternalFileStatus  = $false  # include files from externals in counts
 }

--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -23,6 +23,9 @@ $global:SvnPromptSettings = New-Object PSObject -Property @{
     IncomingStatusSymbol      = [char]0x2193 # Down arrow
     IncomingForegroundColor   = [ConsoleColor]::Red
     IncomingBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+
+    EnableRemoteStatus        = $true   # show remote server status
+    EnableExternalFileStatus  = $false  # include files from externals in counts
 }
 
 function Write-SvnStatus($status) {

--- a/SvnTabExpansion.ps1
+++ b/SvnTabExpansion.ps1
@@ -15,7 +15,7 @@ function SvnTabExpansion($lastBlock) {
 
 function svnCommands($filter) {
   $cmdList = @()
-  $output = svn help
+  $output = & $svn help
   foreach($line in $output) {
     if($line -match '^   (\S+)(.*)') {
       $cmd = $matches[1]

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -37,7 +37,8 @@ function Get-SvnInfo {
                             default { $Matches.Value }
                         }
                         $result.Add($name, $value)
-                    } else {
+                    }
+                    else {
                         throw "line did not match expected pattern: '$_'"
                     }
                 }
@@ -83,24 +84,19 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
         }
 
         & $svn status $statusArgs | ForEach-Object {
-            if ($_ -eq "")
-            {
+            if ($_ -eq "") {
                 # blank line between externals
             }
-            elseif ($_.StartsWith("Status against revision:"))
-            {
-                if ($incomingRevision -eq $null)
-                {
+            elseif ($_.StartsWith("Status against revision:")) {
+                if ($incomingRevision -eq $null) {
                     $incomingRevision = [Int]$_.Replace("Status against revision:", "")
                 }
             }
-            elseif ($_.StartsWith("Performing status on external item at"))
-            {
+            elseif ($_.StartsWith("Performing status on external item at")) {
                 # External
                 # ignore for now.
             }
-            else
-            {
+            else {
                 switch($_[0]) {
                     'A' { $added++; break; }
                     'C' { $conflicted++; break; }
@@ -139,13 +135,12 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
 
 
         $title = ''
-        if ($settings.EnableWindowTitle)
-        {
+        if ($settings.EnableWindowTitle) {
             $repoName = Split-Path -Leaf (Split-Path $svnDir)
             $prefix = if ($settings.EnableWindowTitle -is [string]) { $settings.EnableWindowTitle } else { '' }
             $title = "${prefix}${repoName} [$($branch)]"
         }
-        
+
         return New-Object PSObject -Property @{
             SvnDir = $svnDir
             Title = $title;
@@ -194,28 +189,28 @@ function Get-SvnBranchName($info) {
 }
 
 function tsvn {
-  if($args) {
-    if($args[0] -eq "help") {
-      #I don't like the built in help behaviour!
-      $tsvnCommands.keys | Sort-Object | ForEach-Object { write-host $_ }
+    if ($args) {
+        if ($args[0] -eq "help") {
+            #I don't like the built in help behaviour!
+            $tsvnCommands.keys | Sort-Object | ForEach-Object { write-host $_ }
 
-      return
+            return
+        }
+
+        $newArgs = @()
+        $newArgs += "/command:" + $args[0]
+
+        $cmd = $tsvnCommands[$args[0]]
+        if ($cmd -and $cmd.useCurrentDirectory) {
+            $newArgs += "/path:."
+        }
+
+        if ($args.length -gt 1) {
+            $args[1..$args.length] | % { $newArgs += $_ }
+        }
+
+        tortoiseproc $newArgs
     }
-
-    $newArgs = @()
-    $newArgs += "/command:" + $args[0]
-
-    $cmd = $tsvnCommands[$args[0]]
-    if($cmd -and $cmd.useCurrentDirectory) {
-       $newArgs += "/path:."
-    }
-
-    if($args.length -gt 1) {
-      $args[1..$args.length] | % { $newArgs += $_ }
-    }
-
-    tortoiseproc $newArgs
-  }
 }
 
 function Find-SvnCommand([object[]] $ArgumentList) {
@@ -242,6 +237,6 @@ function Invoke-Svn {
 New-Alias -Name 'svn' -Value 'Invoke-Svn'
 
 function Get-AliasPattern($exe) {
-    $aliases = @($exe) + @(Get-Alias | Where-Object { $_.Definition -eq $exe } | select -Exp Name)
+    $aliases = @($exe) + @(Get-Alias | Where-Object { $_.Definition -eq $exe } | Select-Object -Exp Name)
     "($($aliases -join '|'))"
 }

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -117,8 +117,18 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
             }
         }
 
+
+        $title = ''
+        if ($settings.EnableWindowTitle)
+        {
+            $repoName = Split-Path -Leaf (Split-Path $svnDir)
+            $prefix = if ($settings.EnableWindowTitle -is [string]) { $settings.EnableWindowTitle } else { '' }
+            $title = "${prefix}${repoName} [$($branch)]"
+        }
+        
         return New-Object PSObject -Property @{
             SvnDir = $svnDir
+            TItle = $title;
             Untracked = $untracked;
             Added = $added;
             Modified = $modified + $replaced;

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -248,18 +248,8 @@ function Get-AliasPattern($exe) {
 # Console colors
 #
 
-if (!(Get-Module ConsoleTheme)) {
-    # ConsoleTheme is a (currently private) module that helps with whether the console is light or dark, and chooses colors accordingly.
-    # Eventually I'll release it, but for now use these as fallbacks.
-
-    # Determine whether the shell is light or dark.
-    # Just assume background color gives us enough info for now.
-    $IsDark = switch -Wildcard ($Host.UI.RawUI.BackgroundColor) {
-        "Dark*" { $true }
-        "Black" { $true }
-        default { $false }
-    }
-
+if (!(Get-Command Test-ConsoleColor)) {
+    <# PRIVATE Tests that the value is a valid ConsoleColor #>
     function Test-ConsoleColor {
         [OutputType([bool])]
         param (
@@ -268,43 +258,5 @@ if (!(Get-Module ConsoleTheme)) {
         )
 
         return $Color -ge 0
-    }
-
-    function Get-ConsoleThemeSafeColor {
-        [OutputType([ConsoleColor])]
-        param (
-            [ValidateNotNullOrEmpty()]
-            [Parameter(Position = 0, Mandatory = $true)]
-            [ConsoleColor] $Color
-        )
-
-        Write-Verbose "color=[$($Color.GetType().FullName)]$Color IsDark=$IsDark"
-
-        if ($IsDark) {
-            switch ($Color) {
-                DarkBlue    { [ConsoleColor]::Blue          }
-                DarkCyan    { [ConsoleColor]::Cyan          }
-                DarkGray    { [ConsoleColor]::Gray          }
-                DarkGreen   { [ConsoleColor]::Green         }
-                DarkMagenta { [ConsoleColor]::Magenta       }
-                DarkRed     { [ConsoleColor]::Red           }
-                DarkYellow  { [ConsoleColor]::Yellow        }
-                Black       { [ConsoleColor]::White         }
-                default     { $Color }
-            }
-        }
-        else {
-            switch ($Color) {
-                Blue        { [ConsoleColor]::DarkBlue      }
-                Cyan        { [ConsoleColor]::DarkCyan      }
-                Gray        { [ConsoleColor]::DarkGray      }
-                Green       { [ConsoleColor]::DarkGreen     }
-                Magenta     { [ConsoleColor]::DarkMagenta   }
-                Red         { [ConsoleColor]::DarkRed       }
-                Yellow      { [ConsoleColor]::DarkYellow    }
-                White       { [ConsoleColor]::Black         }
-                default     { $Color }
-            }
-        }
     }
 }

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -233,19 +233,8 @@ function Find-SvnCommand([object[]] $ArgumentList) {
 # svn doesn't have this built in (as of 1.9.7) so we have to do it ourselves.
 $less = Get-Command 'less' -ErrorAction SilentlyContinue
 if ($less) {
-    $lessCommands = @('help', 'log')
-    [string[]] $lessOpts = @()
-
-    if ($less.CommandType -eq 'Application') {
-        # ASSUMPTION: application (binary) == GNU less
-        $lessOpts = @(
-            '--no-init',             # don't clear the screen on exit
-            '--quit-if-one-screen'   # If the shell supports it, don't stay in less if the content fits on the screen.
-        )
-    }
+    $lessCommands = @('diff', 'help', 'log')
 }
-
-
 
 function Invoke-Svn {
     if ($less) {

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -253,8 +253,6 @@ function Invoke-Svn {
         if ($lessCommands -contains $command) {
             # FIXME this shows the BOM when using Cygwin less, how do I not show BOM regardless of encoding?
             return & $svn $args | & $less $lessOpts
-        } else {
-            Write-Warning "command '$command' not in $lessCommands"
         }
     }
 

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -240,3 +240,68 @@ function Get-AliasPattern($exe) {
     $aliases = @($exe) + @(Get-Alias | Where-Object { $_.Definition -eq $exe } | Select-Object -Exp Name)
     "($($aliases -join '|'))"
 }
+
+#
+# Console colors
+#
+
+if (!(Get-Module ConsoleTheme)) {
+    # ConsoleTheme is a (currently private) module that helps with whether the console is light or dark, and chooses colors accordingly.
+    # Eventually I'll release it, but for now use these as fallbacks.
+
+    # Determine whether the shell is light or dark.
+    # Just assume background color gives us enough info for now.
+    $IsDark = switch -Wildcard ($Host.UI.RawUI.BackgroundColor) {
+        "Dark*" { $true }
+        "Black" { $true }
+        default { $false }
+    }
+
+    function Test-ConsoleColor {
+        [OutputType([bool])]
+        param (
+            [Parameter(Position = 0)]
+            [Nullable[ConsoleColor]] $Color
+        )
+
+        return $Color -ge 0
+    }
+
+    function Get-ConsoleThemeSafeColor {
+        [OutputType([ConsoleColor])]
+        param (
+            [ValidateNotNullOrEmpty()]
+            [Parameter(Position = 0, Mandatory = $true)]
+            [ConsoleColor] $Color
+        )
+
+        Write-Verbose "color=[$($Color.GetType().FullName)]$Color IsDark=$IsDark"
+
+        if ($IsDark) {
+            switch ($Color) {
+                DarkBlue    { [ConsoleColor]::Blue          }
+                DarkCyan    { [ConsoleColor]::Cyan          }
+                DarkGray    { [ConsoleColor]::Gray          }
+                DarkGreen   { [ConsoleColor]::Green         }
+                DarkMagenta { [ConsoleColor]::Magenta       }
+                DarkRed     { [ConsoleColor]::Red           }
+                DarkYellow  { [ConsoleColor]::Yellow        }
+                Black       { [ConsoleColor]::White         }
+                default     { $Color }
+            }
+        }
+        else {
+            switch ($Color) {
+                Blue        { [ConsoleColor]::DarkBlue      }
+                Cyan        { [ConsoleColor]::DarkCyan      }
+                Gray        { [ConsoleColor]::DarkGray      }
+                Green       { [ConsoleColor]::DarkGreen     }
+                Magenta     { [ConsoleColor]::DarkMagenta   }
+                Red         { [ConsoleColor]::DarkRed       }
+                Yellow      { [ConsoleColor]::DarkYellow    }
+                White       { [ConsoleColor]::Black         }
+                default     { $Color }
+            }
+        }
+    }
+}

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -225,6 +225,9 @@ $pagerCommands = @('diff', 'help', 'log')
 
 function Invoke-Svn {
     if ($Env:PAGER) {
+        # Set local output encoding to CONSOLE output to make sure BOMs don't show up in the UI if the user set their encoding to UTF8/UTF16
+        $OutputEncoding = [System.Console]::OutputEncoding
+
         $command = Find-SvnCommand -ArgumentList $args
         if ($pagerCommands -contains $command) {
             return & $svn $args | & $Env:PAGER

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -87,16 +87,14 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
             $statusArgs += '--ignore-externals'
         }
 
-        $status = svn status $statusArgs
-
-        foreach($line in $status) {
-            if ($line.StartsWith("Status"))
+        svn status $statusArgs | ForEach-Object {
+            if ($_.StartsWith("Status"))
             {
-                $incomingRevision = [Int]$line.Replace("Status against revision:", "")
+                $incomingRevision = [Int]$_.Replace("Status against revision:", "")
             }
             else
             {
-                switch($line[0]) {
+                switch($_[0]) {
                     'A' { $added++; break; }
                     'C' { $conflicted++; break; }
                     'D' { $deleted++; break; }
@@ -108,13 +106,13 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
                     '!' { $missing++; break; }
                     '~' { $obstructed++; break; }
                 }
-                switch($line[4]) {
+                switch($_[4]) {
                     'X' { $external++; break; }
                 }
-                switch($line[6]) {
+                switch($_[6]) {
                     'C' { $conflicted++; break; }
                 }
-                switch($line[8]) {
+                switch($_[8]) {
                     '*' { $incoming++; break; }
                 }
             }

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -131,14 +131,16 @@ function Get-SvnStatus($svnDir = (Get-SvnDirectory)) {
         
         return New-Object PSObject -Property @{
             SvnDir = $svnDir
-            TItle = $title;
-            Untracked = $untracked;
+            Title = $title;
             Added = $added;
             Modified = $modified + $replaced;
             Deleted = $deleted;
+            HasIndex = [bool]($added -or $modified -or $replaced -or $deleted)
+            Untracked = $untracked;
             Missing = $missing;
             Obstructed = $obstructed;
             Conflicted = $conflicted;
+            HasWorking = [bool]($untracked -or $missing -or $obstructed -or $conflicted)
             External = $external;
             Incoming = $incoming
             Url = $info.Url

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -95,14 +95,27 @@ function Get-SvnBranchInfo {
 
     $pathBits = $url.Split("/", [StringSplitOptions]::RemoveEmptyEntries)
 
-    if($pathBits[0] -eq "trunk") {
-      $branch =  "trunk";
+    $branch = 'UNKNOWN'
+    for ($i = 0; $i -lt $pathBits.length; $i++) {
+        switch -regex ($pathBits[$i]) {
+            "trunk" {
+                $branch = $pathBits[$i]
+                break
+            }
+            "branches|tags" {
+                $next = $i + 1
+                if ($next -lt $pathBits.Length) {
+                    $branch = $pathBits[$next]
+                    break
+                }
+            }
+        }
     }
-    elseif($pathBits[0] -match "branches|tags") {
-      $branch = $pathBits[1]
+
+    return @{
+        "Branch" = $branch
+        "Revision" = $revision
     }
-    return @{"Branch" = $branch;
-             "Revision" = $revision}
   }
 }
 

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.101'
+ModuleVersion = '0.7.200'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -1,0 +1,62 @@
+@{
+
+# Script module or binary module file associated with this manifest.
+ModuleToProcess = 'posh-svn.psm1'
+
+# Version number of this module.
+ModuleVersion = '0.7.1'
+
+# ID used to uniquely identify this module
+GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'
+
+# Author of this module
+Author = 'Jeremy Skinner and contributors'
+
+# Copyright statement for this module
+Copyright = '(c) 2010-2017 Jeremy Skinner and contributors'
+
+# Description of the functionality provided by this module
+Description = 'Provides prompt with Subversion status summary information and tab completion for Subversion commands, parameters, remotes and branch names.'
+
+# Minimum version of the Windows PowerShell engine required by this module
+PowerShellVersion = '2.0'
+
+# Functions to export from this module
+FunctionsToExport = @(
+    'Write-SvnStatus',
+    'Get-SvnStatus',
+    'Get-SvnInfo',
+    'TabExpansion',
+    'tsvn'
+)
+
+# Cmdlets to export from this module
+CmdletsToExport = @()
+
+# Variables to export from this module
+VariablesToExport = @()
+
+# Aliases to export from this module
+AliasesToExport = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess.
+# This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+PrivateData = @{
+
+    PSData = @{
+        # Tags applied to this module. These help with module discovery in online galleries.
+        Tags = @('svn', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
+
+        # A URL to the license for this module.
+       # LicenseUri = 'https://github.com/imobile3/posh-svn/blob/v0.7.1/LICENSE.txt'
+
+        # A URL to the main website for this project.
+        ProjectUri = 'https://github.com/imobile3/posh-svn'
+
+        # ReleaseNotes of this module
+        #ReleaseNotes = 'https://github.com/imobile3/posh-svn/blob/v0.7.1/CHANGELOG.md'
+    }
+
+}
+
+}

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,16 +4,16 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.1'
+ModuleVersion = '0.7.100'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'
 
 # Author of this module
-Author = 'Jeremy Skinner and contributors'
+Author = 'Chris Donnelly, Jeremy Skinner and contributors'
 
 # Copyright statement for this module
-Copyright = '(c) 2010-2017 Jeremy Skinner and contributors'
+Copyright = '(c) 2010-2017 Chris Donnelly, Jeremy Skinner and contributors'
 
 # Description of the functionality provided by this module
 Description = 'Provides prompt with Subversion status summary information and tab completion for Subversion commands, parameters, remotes and branch names.'

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.202'
+ModuleVersion = '0.7.300'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'
@@ -22,13 +22,7 @@ Description = 'Provides prompt with Subversion status summary information and ta
 PowerShellVersion = '2.0'
 
 # Functions to export from this module
-FunctionsToExport = @(
-    'Write-SvnStatus',
-    'Get-SvnStatus',
-    'Get-SvnInfo',
-    'TabExpansion',
-    'tsvn'
-)
+FunctionsToExport = '*'
 
 # Cmdlets to export from this module
 CmdletsToExport = @()
@@ -37,7 +31,7 @@ CmdletsToExport = @()
 VariablesToExport = @()
 
 # Aliases to export from this module
-AliasesToExport = @()
+AliasesToExport = '*'
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess.
 # This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.100'
+ModuleVersion = '0.7.101'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.300'
+ModuleVersion = '0.7.301'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.200'
+ModuleVersion = '0.7.201'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'

--- a/posh-svn.psd1
+++ b/posh-svn.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-svn.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.201'
+ModuleVersion = '0.7.202'
 
 # ID used to uniquely identify this module
 GUID = 'f18820b6-2e02-41b4-afc5-de886bb1b848'

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -53,12 +53,18 @@ $ScriptStackTraceMinVersion = [Version]'3.0'
             }
             catch {
                 $count = 0
-                $errors = for ($ex = $_.Exception; $ex; $ex = $ex.InnerException) {
-                    if ($count++ -gt 0) { "`n -----> " + $ex.ErrorRecord } else { $ex.ErrorRecord }
-                    if ($PSVersionTable.PSVersion -ge $ScriptStackTraceMinVersion)
-                    {
+                if ($PSVersionTable.PSVersion -ge $ScriptStackTraceMinVersion)
+                {
+                    $errors = for ($ex = $_.Exception; $ex; $ex = $ex.InnerException) {
+                        if ($count++ -gt 0) { "`n -----> " + $ex.ErrorRecord } else { $ex.ErrorRecord }
                         "Stack trace:"
                         $ex.ErrorRecord.ScriptStackTrace
+                    }
+                }
+                else
+                {
+                    $errors = for ($ex = $_.Exception; $ex; $ex = $ex.InnerException) {
+                        if ($count++ -gt 0) { "`n -----> " + $ex } else { $ex }
                     }
                 }
 

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -11,19 +11,23 @@ if ($psv.Major -lt 3 -and !$NoVersionWarn) {
     "To suppress this warning, change your profile to include 'Import-Module posh-svn -Args `$true'.")
 }
 
+# Refer to svn application command via this, as we alias it.
+$svn = $null
+
 # & $PSScriptRoot\CheckVersion.ps1 > $null
 New-TimingInfo -Name CheckVersion -Command {
     $Global:SvnMissing = $false
 
-    if (!(Get-Command svn -TotalCount 1 -ErrorAction SilentlyContinue)) {
-        Write-Warning "svn command could not be found. Please create an alias or add it to your PATH."
+    $svn = Get-Command 'svn' -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
+    if (!$svn) {
+        Write-Warning "svn application command could not be found. Please create an alias or add it to your PATH."
         $Global:SvnMissing = $true
         return
     }
 
     # HACK determine a minimum required version, 1.6.0 is a guess
     $requiredVersion = [Version]'1.6.0'
-    if ([String](svn --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+    if ([String](& $svn --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
         $version = [Version]$Matches['ver']
     }
     if ($version -lt $requiredVersion) {
@@ -69,6 +73,8 @@ Export-ModuleMember -Function @(
     'Get-SvnStatus',
     'Get-SvnInfo',
     'TabExpansion',
-    'tsvn'
-)
+    'tsvn',
+    'Invoke-Svn'
+) -Alias @('svn')
+
 

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -1,4 +1,4 @@
-param([switch]$NoVersionWarn)
+param([switch] $NoVersionWarn)
 
 if (Get-Module posh-svn) { return }
 
@@ -61,11 +61,6 @@ New-TimingInfo -Name CheckVersion -Command {
         }
     }
 
-#. $PSScriptRoot\SvnUtils.ps1
-#. $PSScriptRoot\SvnPrompt.ps1
-#. $PSScriptRoot\SvnTabExpansion.ps1
-
-
 Export-ModuleMember -Function @(
     'Write-SvnStatus',
     'Get-SvnStatus',
@@ -73,6 +68,8 @@ Export-ModuleMember -Function @(
     'TabExpansion',
     'tsvn',
     'Invoke-Svn'
-) -Alias @('svn')
+) -Alias @(
+    'svn'
+)
 
 

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -36,6 +36,9 @@ New-TimingInfo -Name CheckVersion -Command {
     }
 }
 
+# TODO when was ScriptStackTrace added? It's not in 2.0...
+$ScriptStackTraceMinVersion = [Version]'3.0'
+
 @('SvnUtils', 'SvnPrompt', 'SvnTabExpansion') |
     ForEach-Object {
         New-TimingInfo -Name $_ -Command {
@@ -52,8 +55,11 @@ New-TimingInfo -Name CheckVersion -Command {
                 $count = 0
                 $errors = for ($ex = $_.Exception; $ex; $ex = $ex.InnerException) {
                     if ($count++ -gt 0) { "`n -----> " + $ex.ErrorRecord } else { $ex.ErrorRecord }
-                    "Stack trace:"
-                    $ex.ErrorRecord.ScriptStackTrace
+                    if ($PSVersionTable.PSVersion -ge $ScriptStackTraceMinVersion)
+                    {
+                        "Stack trace:"
+                        $ex.ErrorRecord.ScriptStackTrace
+                    }
                 }
 
                 throw "Cannot process script '${fullName}':`n$errors"

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -13,9 +13,23 @@ if ($psv.Major -lt 3 -and !$NoVersionWarn) {
 
 & $PSScriptRoot\CheckVersion.ps1 > $null
 
-. $PSScriptRoot\SvnUtils.ps1
-. $PSScriptRoot\SvnPrompt.ps1
-. $PSScriptRoot\SvnTabExpansion.ps1
+@('SvnUtils', 'SvnPrompt', 'SvnTabExpansion') |
+    ForEach-Object {
+        New-TimingInfo -Name $_ -Command {
+            # @see https://becomelotr.wordpress.com/2017/02/13/expensive-dot-sourcing/
+            $ExecutionContext.InvokeCommand.InvokeScript(
+                $false,
+                [scriptblock]::Create([io.file]::ReadAllText("${PSScriptRoot}\${_}.ps1", [Text.Encoding]::UTF8)),
+                $null,
+                $null
+            );
+        } 
+    }
+
+#. $PSScriptRoot\SvnUtils.ps1
+#. $PSScriptRoot\SvnPrompt.ps1
+#. $PSScriptRoot\SvnTabExpansion.ps1
+
 
 Export-ModuleMember -Function @(
     'Write-SvnStatus',

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -11,7 +11,26 @@ if ($psv.Major -lt 3 -and !$NoVersionWarn) {
     "To suppress this warning, change your profile to include 'Import-Module posh-svn -Args `$true'.")
 }
 
-& $PSScriptRoot\CheckVersion.ps1 > $null
+# & $PSScriptRoot\CheckVersion.ps1 > $null
+New-TimingInfo -Name CheckVersion -Command {
+    $Global:SvnMissing = $false
+
+    if (!(Get-Command svn -TotalCount 1 -ErrorAction SilentlyContinue)) {
+        Write-Warning "svn command could not be found. Please create an alias or add it to your PATH."
+        $Global:SvnMissing = $true
+        return
+    }
+
+    # HACK determine a minimum required version, 1.6.0 is a guess
+    $requiredVersion = [Version]'1.6.0'
+    if ([String](svn --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+        $version = [Version]$Matches['ver']
+    }
+    if ($version -lt $requiredVersion) {
+        Write-Warning "posh-svn requires Subversion $requiredVersion or better. You have $version."
+        return
+    }
+}
 
 @('SvnUtils', 'SvnPrompt', 'SvnTabExpansion') |
     ForEach-Object {

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -39,8 +39,7 @@ New-TimingInfo -Name CheckVersion -Command {
 @('SvnUtils', 'SvnPrompt', 'SvnTabExpansion') |
     ForEach-Object {
         New-TimingInfo -Name $_ -Command {
-            try
-            {
+            try {
                 # @see https://becomelotr.wordpress.com/2017/02/13/expensive-dot-sourcing/
                 $ExecutionContext.InvokeCommand.InvokeScript(
                     $false,
@@ -49,8 +48,7 @@ New-TimingInfo -Name CheckVersion -Command {
                     $null
                 );
             }
-            catch
-            {
+            catch {
                 $count = 0
                 $errors = for ($ex = $_.Exception; $ex; $ex = $ex.InnerException) {
                     if ($count++ -gt 0) { "`n -----> " + $ex.ErrorRecord } else { $ex.ErrorRecord }
@@ -59,8 +57,8 @@ New-TimingInfo -Name CheckVersion -Command {
                 }
 
                 throw "Cannot process script '${fullName}':`n$errors"
-            }            
-        } 
+            }
+        }
     }
 
 #. $PSScriptRoot\SvnUtils.ps1

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -1,15 +1,27 @@
-if (Get-Command svn -errorAction SilentlyContinue)
-{
-  Push-Location $psScriptRoot
-  . ./SvnUtils.ps1
-  . ./SvnPrompt.ps1
-  . ./SvnTabExpansion.ps1
-  Pop-Location
+param([switch]$NoVersionWarn)
 
-  Export-ModuleMember -Function @(
+if (Get-Module posh-svn) { return }
+
+$psv = $PSVersionTable.PSVersion
+
+if ($psv.Major -lt 3 -and !$NoVersionWarn) {
+    Write-Warning ("posh-svn support for PowerShell 2.0 is deprecated; you have version $($psv).`n" +
+    "To download version 5.0, please visit https://www.microsoft.com/en-us/download/details.aspx?id=50395`n" +
+    "For more information and to discuss this, please visit **TODO PR**`n" +
+    "To suppress this warning, change your profile to include 'Import-Module posh-svn -Args `$true'.")
+}
+
+& $PSScriptRoot\CheckVersion.ps1 > $null
+
+. $PSScriptRoot\SvnUtils.ps1
+. $PSScriptRoot\SvnPrompt.ps1
+. $PSScriptRoot\SvnTabExpansion.ps1
+
+Export-ModuleMember -Function @(
     'Write-SvnStatus',
     'Get-SvnStatus',
+    'Get-SvnInfo',
     'TabExpansion',
     'tsvn'
-  )
-}
+)
+


### PR DESCRIPTION
Fixed problem where it assumed `trunk`/`branches`/`tags` was always the first entry in the relative URL.  That is not always true - a repo can have multiple directories each with their own `trunk`/`branches`/`tags`.